### PR TITLE
Fix super-admin session handling and admin interface

### DIFF
--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -1,0 +1,59 @@
+h2 {
+  margin-bottom: 1.5rem;
+  font-size: 1.8rem;
+  color: #333;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+thead th {
+  background-color: #f3f4f6;
+  color: #374151;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.85rem;
+}
+
+td,
+th {
+  padding: 0.75rem 1rem;
+  border: 1px solid #e5e7eb;
+  text-align: left;
+}
+
+tbody tr:nth-child(even) {
+  background-color: #f9fafb;
+}
+
+.actions .action-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.actions a {
+  color: #2563eb;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.actions a:hover {
+  text-decoration: underline;
+}
+
+.actions .no-action {
+  color: #9ca3af;
+  font-style: italic;
+}
+
+.actions .restricted {
+  color: #6b7280;
+  font-size: 0.85rem;
+  font-style: italic;
+}

--- a/templates/admin_accounts.html
+++ b/templates/admin_accounts.html
@@ -17,6 +17,8 @@
     </tr>
   </thead>
   <tbody>
+    {% set viewer_is_superadmin = session.get('is_superadmin') %}
+    {% set viewer_id = session.get('user_id') %}
     {% for user in users %}
     <tr>
       <td>{{ user.id }}</td>
@@ -24,24 +26,27 @@
       <td>{{ "Oui" if user.validated else "Non" }}</td>
       <td>{{ "Oui" if user.is_admin else "Non" }}</td>
       <td>{{ "Oui" if user.is_superadmin else "Non" }}</td>
-      <td>
-        {% if not user.validated %}
-          <a href="{{ url_for('approve_account', user_id=user.id) }}">Approuver</a>
-          {% if not user.is_admin %}
-            | <a href="{{ url_for('delete_account', user_id=user.id) }}" onclick="return confirm('Supprimer cet utilisateur ?');">Supprimer</a>
+      <td class="actions">
+        <div class="action-items">
+          {% if not user.validated %}
+            <a href="{{ url_for('approve_account', user_id=user.id) }}">Approuver</a>
           {% endif %}
-        {% else %}
+
           {% if not user.is_admin %}
+            <a href="{{ url_for('promote_account', user_id=user.id) }}">Promouvoir en admin</a>
             <a href="{{ url_for('delete_account', user_id=user.id) }}" onclick="return confirm('Supprimer cet utilisateur ?');">Supprimer</a>
           {% else %}
-            {% if not user.is_superadmin %}
-              <a href="{{ url_for('promote_account', user_id=user.id) }}">Promouvoir en admin</a> |
+            {% if user.is_superadmin %}
+              <span class="no-action">-</span>
+            {% elif viewer_is_superadmin and user.id != viewer_id %}
               <a href="{{ url_for('delete_account', user_id=user.id) }}" onclick="return confirm('Supprimer cet utilisateur ?');">Supprimer</a>
+            {% elif user.id == viewer_id %}
+              <span class="no-action" title="Action indisponible sur votre propre compte">-</span>
             {% else %}
-              <span>-</span>
+              <span class="restricted" title="Action réservée au super-admin">Super-admin requis</span>
             {% endif %}
           {% endif %}
-        {% endif %}
+        </div>
       </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
## Summary
- persist the super-admin flag in the session during login so privileged actions stay accessible
- adjust the admin accounts template to expose promotion links for non-admin users and tidy action display
- add a dedicated stylesheet for the admin accounts table styling
- harden the admin decorators to refresh privilege flags and handle expired sessions gracefully
- clarify the admin interface by only surfacing destructive admin actions to super-admin viewers

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d13287b8a0832d8a570e4cabfbb3af