### PR TITLE
Add dedicated API key configuration loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,20 @@ BookStorage is a Flask web application that helps readers track what they are cu
    cp .env.example .env
    ```
    Edit `.env` to set `BOOKSTORAGE_SECRET_KEY`, adjust the storage paths, and switch `BOOKSTORAGE_ENV` to `development` or `production` as needed.
-4. **Install the dependencies**
+4. **Configure optional API keys** (skip if you do not plan to use integrations yet)
+   ```bash
+   cp api_keys.example.json api_keys.json
+   ```
+   Fill the file with the credentials you obtained from Google Books, Kitsu, AniList, Comic Vine, etc. Leave values empty when you do not have the corresponding key.
+5. **Install the dependencies**
    ```bash
    pip install -r requirements.txt
    ```
-5. **Initialise the database**
+6. **Initialise the database**
    ```bash
    python init_db.py
    ```
-6. **Run the application**
+7. **Run the application**
    ```bash
    flask --app wsgi --debug run       # development server
    # or
@@ -112,8 +117,13 @@ All configuration is provided through environment variables. When `python-dotenv
 | `BOOKSTORAGE_SUPERADMIN_PASSWORD` | Password assigned to the default super-administrator. Change it immediately in production. | `SuperAdmin!2023` |
 | `BOOKSTORAGE_HOST` | Network interface bound by the application when run via `app.py`. | `127.0.0.1` |
 | `BOOKSTORAGE_PORT` | HTTP port exposed by the application when run via `app.py`. | `5000` |
+| `BOOKSTORAGE_API_CONFIG` | Absolute or relative path to the JSON file that stores optional third-party API keys. | `api_keys.json` |
 
 When `BOOKSTORAGE_ENV=production`, the application refuses to start if `BOOKSTORAGE_SECRET_KEY` is missing.
+
+### API keys file
+
+Third-party integrations are configured through `api_keys.json`. A template is provided as `api_keys.example.json` — copy it next to your `.env` file and fill the credentials you actually need. Any value left empty is treated as missing, so the application keeps working even without external APIs. Set `BOOKSTORAGE_API_CONFIG` if you store the file in another location.
 
 ## Testing
 Run the automated test suite with:
@@ -167,15 +177,20 @@ BookStorage est une application web Flask qui aide les lecteurs à suivre leurs 
    cp .env.example .env
    ```
    Modifiez `.env` pour définir `BOOKSTORAGE_SECRET_KEY`, ajuster les chemins de stockage et choisir `BOOKSTORAGE_ENV=development` ou `production`.
-4. **Installer les dépendances**
+4. **Configurer les clefs d’API facultatives** (ignorez cette étape tant que vous n’utilisez pas d’intégration)
+   ```bash
+   cp api_keys.example.json api_keys.json
+   ```
+   Renseignez le fichier avec les identifiants obtenus auprès de Google Books, Kitsu, AniList, Comic Vine, etc. Laissez les valeurs vides quand aucune clef n’est disponible.
+5. **Installer les dépendances**
    ```bash
    pip install -r requirements.txt
    ```
-5. **Initialiser la base de données**
+6. **Initialiser la base de données**
    ```bash
    python init_db.py
    ```
-6. **Lancer l’application**
+7. **Lancer l’application**
    ```bash
    flask --app wsgi --debug run       # serveur de développement
    # ou
@@ -246,8 +261,13 @@ Toute la configuration passe par des variables d’environnement. Avec `python-d
 | `BOOKSTORAGE_SUPERADMIN_PASSWORD` | Mot de passe associé au super-administrateur par défaut. À changer immédiatement en production. | `SuperAdmin!2023` |
 | `BOOKSTORAGE_HOST` | Interface réseau écoutée lorsque l’application est lancée via `app.py`. | `127.0.0.1` |
 | `BOOKSTORAGE_PORT` | Port HTTP exposé lorsque l’application est lancée via `app.py`. | `5000` |
+| `BOOKSTORAGE_API_CONFIG` | Chemin absolu ou relatif vers le fichier JSON contenant les clefs d’API facultatives. | `api_keys.json` |
 
 Lorsque `BOOKSTORAGE_ENV=production`, l’application refuse de démarrer si `BOOKSTORAGE_SECRET_KEY` n’est pas défini.
+
+### Fichier des clefs d’API
+
+Les intégrations tierces se configurent via `api_keys.json`. Un modèle est fourni (`api_keys.example.json`) : copiez-le à côté de votre `.env` puis renseignez uniquement les clefs nécessaires. Les champs laissés vides sont ignorés, l’application continue donc de fonctionner sans APIs externes. Utilisez `BOOKSTORAGE_API_CONFIG` si le fichier est stocké ailleurs.
 
 ## Tests
 Lancer la suite automatisée avec :

--- a/api_config.py
+++ b/api_config.py
@@ -1,0 +1,91 @@
+"""Dedicated loader for optional third-party API credentials.
+
+This module provides a lightweight configuration layer separate from the main
+application settings so administrators immediately know where to drop their API
+keys.  The loader tolerates missing files and incomplete definitions so the app
+remains fully functional even when no integrations are configured yet.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+DEFAULT_API_CONFIG_NAME = "api_keys.json"
+
+
+@dataclass(frozen=True)
+class APISettings:
+    """Collected credentials for optional external services."""
+
+    google_books_api_key: Optional[str]
+    kitsu_client_id: Optional[str]
+    kitsu_client_secret: Optional[str]
+    anilist_client_id: Optional[str]
+    anilist_client_secret: Optional[str]
+    comic_vine_api_key: Optional[str]
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        """Expose the credentials as a mapping for convenient templating."""
+
+        return {
+            "google_books_api_key": self.google_books_api_key,
+            "kitsu_client_id": self.kitsu_client_id,
+            "kitsu_client_secret": self.kitsu_client_secret,
+            "anilist_client_id": self.anilist_client_id,
+            "anilist_client_secret": self.anilist_client_secret,
+            "comic_vine_api_key": self.comic_vine_api_key,
+        }
+
+
+def _normalise(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return str(value)
+
+
+def load_api_settings(root_path: Path | str) -> APISettings:
+    """Load API credentials from JSON if available.
+
+    Parameters
+    ----------
+    root_path:
+        Base directory used to resolve relative configuration paths.  This is
+        typically the Flask application's ``root_path``.
+    """
+
+    root = Path(root_path)
+    candidate = os.environ.get("BOOKSTORAGE_API_CONFIG", DEFAULT_API_CONFIG_NAME).strip()
+    config_path = Path(candidate) if candidate else Path(DEFAULT_API_CONFIG_NAME)
+    if not config_path.is_absolute():
+        config_path = root / config_path
+
+    if not config_path.exists():
+        return APISettings(None, None, None, None, None, None)
+
+    try:
+        with config_path.open("r", encoding="utf-8") as handle:
+            raw: Dict[str, Any] = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Impossible de lire les clefs API depuis {config_path}: JSON invalide"
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(
+            f"Impossible d'ouvrir le fichier de clefs API {config_path}"
+        ) from exc
+
+    return APISettings(
+        google_books_api_key=_normalise(raw.get("google_books_api_key")),
+        kitsu_client_id=_normalise(raw.get("kitsu_client_id")),
+        kitsu_client_secret=_normalise(raw.get("kitsu_client_secret")),
+        anilist_client_id=_normalise(raw.get("anilist_client_id")),
+        anilist_client_secret=_normalise(raw.get("anilist_client_secret")),
+        comic_vine_api_key=_normalise(raw.get("comic_vine_api_key")),
+    )

--- a/api_keys.example.json
+++ b/api_keys.example.json
@@ -1,0 +1,8 @@
+{
+  "google_books_api_key": "VOTRE_CLE_GOOGLE_BOOKS",
+  "kitsu_client_id": "",
+  "kitsu_client_secret": "",
+  "anilist_client_id": "",
+  "anilist_client_secret": "",
+  "comic_vine_api_key": ""
+}

--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - executed when python-dotenv is absent
     load_dotenv = None  # type: ignore
 
+from api_config import APISettings, load_api_settings
 
 if load_dotenv is not None:  # pragma: no cover - simple delegation
     # Load a .env file located at the project root if present. ``override``
@@ -52,6 +53,7 @@ class Settings:
     environment: str
     host: str
     port: int
+    api_settings: APISettings
 
 
 def _resolve_directory(root: Path, candidate: Optional[str], default: str) -> Path:
@@ -150,6 +152,7 @@ def get_settings(root_path: Path | str) -> Settings:
         environment=environment,
         host=host,
         port=port,
+        api_settings=load_api_settings(root),
     )
 
 
@@ -173,6 +176,7 @@ def configure_app(app):
     app.config["BOOKSTORAGE_SECRET_FROM_ENV"] = settings.secret_from_env
     app.config.setdefault("BOOKSTORAGE_HOST", settings.host)
     app.config.setdefault("BOOKSTORAGE_PORT", settings.port)
+    app.config.setdefault("BOOKSTORAGE_API_SETTINGS", settings.api_settings)
 
     if settings.environment == "production":
         # Harden session cookies by default when the production profile is

--- a/tests/test_api_config.py
+++ b/tests/test_api_config.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from api_config import APISettings, load_api_settings
+
+
+def test_missing_file_returns_empty_settings(tmp_path, monkeypatch):
+    monkeypatch.delenv("BOOKSTORAGE_API_CONFIG", raising=False)
+
+    settings = load_api_settings(tmp_path)
+
+    assert settings == APISettings(None, None, None, None, None, None)
+
+
+def test_load_api_settings_reads_values(tmp_path, monkeypatch):
+    monkeypatch.delenv("BOOKSTORAGE_API_CONFIG", raising=False)
+    config_path = tmp_path / "api_keys.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "google_books_api_key": "  token  ",
+                "kitsu_client_id": "client",
+                "kitsu_client_secret": "secret",
+                "anilist_client_id": "",
+                "anilist_client_secret": None,
+                "comic_vine_api_key": "123",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    settings = load_api_settings(tmp_path)
+
+    assert settings.google_books_api_key == "token"
+    assert settings.kitsu_client_id == "client"
+    assert settings.kitsu_client_secret == "secret"
+    assert settings.anilist_client_id is None
+    assert settings.anilist_client_secret is None
+    assert settings.comic_vine_api_key == "123"
+
+
+def test_environment_override_accepts_absolute_path(tmp_path, monkeypatch):
+    config_path = tmp_path / "custom.json"
+    config_path.write_text(json.dumps({"google_books_api_key": "abc"}), encoding="utf-8")
+    monkeypatch.setenv("BOOKSTORAGE_API_CONFIG", str(config_path))
+
+    settings = load_api_settings(Path("/does/not/matter"))
+
+    assert settings.google_books_api_key == "abc"
+    assert settings.kitsu_client_id is None


### PR DESCRIPTION
## Summary
- add an `api_config` helper that reads optional API credentials from a JSON file and exposes them through the Flask config
- provide an `api_keys.example.json` template and update the English and French README sections to document the setup
- cover the loader with unit tests to ensure missing files, populated files, and environment overrides work as expected

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d505c459cc832dac63107d711413da