### PR TITLE
Add automatic Open Library metadata search

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ BookStorage is a Flask web application that helps readers track what they are cu
 - Reading dashboard: add works with covers, status, chapter counters, reading type (novel, manga, comics, manhwa, etc.), and quick update actions.
 - Community sharing: browse public profiles, search for users, and import works from their libraries into your own.
 - Administration console: approve registrations, promote accounts, and remove users with safeguards for administrator and super-administrator roles.
+- Automatic metadata lookup: fetch suggestions from Open Library directly from the add form, no API keys required.
 
 ## Requirements
 - Python 3.9 or newer.
@@ -33,15 +34,20 @@ BookStorage is a Flask web application that helps readers track what they are cu
    cp .env.example .env
    ```
    Edit `.env` to set `BOOKSTORAGE_SECRET_KEY`, adjust the storage paths, and switch `BOOKSTORAGE_ENV` to `development` or `production` as needed.
-4. **Install the dependencies**
+4. **Configure optional API keys** (skip if you are happy with the built-in Open Library integration)
+   ```bash
+   cp api_keys.example.json api_keys.json
+   ```
+   Fill the file with the credentials you obtained from Google Books, Kitsu, AniList, Comic Vine, etc. Leave values empty when you do not have the corresponding key.
+5. **Install the dependencies**
    ```bash
    pip install -r requirements.txt
    ```
-5. **Initialise the database**
+6. **Initialise the database**
    ```bash
    python init_db.py
    ```
-6. **Run the application**
+7. **Run the application**
    ```bash
    flask --app wsgi --debug run       # development server
    # or
@@ -112,8 +118,17 @@ All configuration is provided through environment variables. When `python-dotenv
 | `BOOKSTORAGE_SUPERADMIN_PASSWORD` | Password assigned to the default super-administrator. Change it immediately in production. | `SuperAdmin!2023` |
 | `BOOKSTORAGE_HOST` | Network interface bound by the application when run via `app.py`. | `127.0.0.1` |
 | `BOOKSTORAGE_PORT` | HTTP port exposed by the application when run via `app.py`. | `5000` |
+| `BOOKSTORAGE_API_CONFIG` | Absolute or relative path to the JSON file that stores optional third-party API keys. | `api_keys.json` |
 
 When `BOOKSTORAGE_ENV=production`, the application refuses to start if `BOOKSTORAGE_SECRET_KEY` is missing.
+
+### API keys file
+
+Third-party integrations are configured through `api_keys.json`. A template is provided as `api_keys.example.json` — copy it next to your `.env` file and fill the credentials you actually need. Any value left empty is treated as missing, so the application keeps working even without external APIs. Set `BOOKSTORAGE_API_CONFIG` if you store the file in another location.
+
+### Automatic metadata suggestions
+
+The add-work page embeds a direct Open Library search so users can fetch titles, authors, covers, and suggested reading types without configuring anything. The button is optional: administrators may still add works manually or extend the integration with extra providers by filling `api_keys.json` when they need richer sources (Google Books, AniList, etc.).
 
 ## Testing
 Run the automated test suite with:
@@ -143,6 +158,7 @@ BookStorage est une application web Flask qui aide les lecteurs à suivre leurs 
 - Tableau de bord de lecture : ajouter des œuvres avec couverture, statut, compteur de chapitres, type de lecture (roman, manga, BD, manhwa, etc.) et actions rapides.
 - Partage communautaire : parcourir les profils publics, rechercher un utilisateur et importer des œuvres depuis sa bibliothèque.
 - Console d’administration : approuver les inscriptions, promouvoir des comptes et supprimer des utilisateurs avec des garde-fous pour les rôles administrateur et super-administrateur.
+- Recherche automatique de métadonnées : interrogez Open Library depuis le formulaire d’ajout pour préremplir les champs sans clef API.
 
 ## Prérequis
 - Python 3.9 ou supérieur.
@@ -167,15 +183,20 @@ BookStorage est une application web Flask qui aide les lecteurs à suivre leurs 
    cp .env.example .env
    ```
    Modifiez `.env` pour définir `BOOKSTORAGE_SECRET_KEY`, ajuster les chemins de stockage et choisir `BOOKSTORAGE_ENV=development` ou `production`.
-4. **Installer les dépendances**
+4. **Configurer les clefs d’API facultatives** (ignorez cette étape si l’intégration Open Library par défaut vous suffit)
+   ```bash
+   cp api_keys.example.json api_keys.json
+   ```
+   Renseignez le fichier avec les identifiants obtenus auprès de Google Books, Kitsu, AniList, Comic Vine, etc. Laissez les valeurs vides quand aucune clef n’est disponible.
+5. **Installer les dépendances**
    ```bash
    pip install -r requirements.txt
    ```
-5. **Initialiser la base de données**
+6. **Initialiser la base de données**
    ```bash
    python init_db.py
    ```
-6. **Lancer l’application**
+7. **Lancer l’application**
    ```bash
    flask --app wsgi --debug run       # serveur de développement
    # ou
@@ -246,8 +267,17 @@ Toute la configuration passe par des variables d’environnement. Avec `python-d
 | `BOOKSTORAGE_SUPERADMIN_PASSWORD` | Mot de passe associé au super-administrateur par défaut. À changer immédiatement en production. | `SuperAdmin!2023` |
 | `BOOKSTORAGE_HOST` | Interface réseau écoutée lorsque l’application est lancée via `app.py`. | `127.0.0.1` |
 | `BOOKSTORAGE_PORT` | Port HTTP exposé lorsque l’application est lancée via `app.py`. | `5000` |
+| `BOOKSTORAGE_API_CONFIG` | Chemin absolu ou relatif vers le fichier JSON contenant les clefs d’API facultatives. | `api_keys.json` |
 
 Lorsque `BOOKSTORAGE_ENV=production`, l’application refuse de démarrer si `BOOKSTORAGE_SECRET_KEY` n’est pas défini.
+
+### Fichier des clefs d’API
+
+Les intégrations tierces se configurent via `api_keys.json`. Un modèle est fourni (`api_keys.example.json`) : copiez-le à côté de votre `.env` puis renseignez uniquement les clefs nécessaires. Les champs laissés vides sont ignorés, l’application continue donc de fonctionner sans APIs externes. Utilisez `BOOKSTORAGE_API_CONFIG` si le fichier est stocké ailleurs.
+
+### Suggestions automatiques de métadonnées
+
+La page d’ajout d’une œuvre intègre une recherche Open Library permettant de récupérer titre, auteurs, couverture et type de lecture sans aucune configuration. Le bouton reste facultatif : les administrateurs peuvent continuer à saisir les informations à la main ou enrichir l’intégration avec d’autres fournisseurs en renseignant `api_keys.json` si des sources supplémentaires (Google Books, AniList, etc.) sont nécessaires.
 
 ## Tests
 Lancer la suite automatisée avec :

--- a/api_config.py
+++ b/api_config.py
@@ -1,0 +1,91 @@
+"""Dedicated loader for optional third-party API credentials.
+
+This module provides a lightweight configuration layer separate from the main
+application settings so administrators immediately know where to drop their API
+keys.  The loader tolerates missing files and incomplete definitions so the app
+remains fully functional even when no integrations are configured yet.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+DEFAULT_API_CONFIG_NAME = "api_keys.json"
+
+
+@dataclass(frozen=True)
+class APISettings:
+    """Collected credentials for optional external services."""
+
+    google_books_api_key: Optional[str]
+    kitsu_client_id: Optional[str]
+    kitsu_client_secret: Optional[str]
+    anilist_client_id: Optional[str]
+    anilist_client_secret: Optional[str]
+    comic_vine_api_key: Optional[str]
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        """Expose the credentials as a mapping for convenient templating."""
+
+        return {
+            "google_books_api_key": self.google_books_api_key,
+            "kitsu_client_id": self.kitsu_client_id,
+            "kitsu_client_secret": self.kitsu_client_secret,
+            "anilist_client_id": self.anilist_client_id,
+            "anilist_client_secret": self.anilist_client_secret,
+            "comic_vine_api_key": self.comic_vine_api_key,
+        }
+
+
+def _normalise(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return str(value)
+
+
+def load_api_settings(root_path: Path | str) -> APISettings:
+    """Load API credentials from JSON if available.
+
+    Parameters
+    ----------
+    root_path:
+        Base directory used to resolve relative configuration paths.  This is
+        typically the Flask application's ``root_path``.
+    """
+
+    root = Path(root_path)
+    candidate = os.environ.get("BOOKSTORAGE_API_CONFIG", DEFAULT_API_CONFIG_NAME).strip()
+    config_path = Path(candidate) if candidate else Path(DEFAULT_API_CONFIG_NAME)
+    if not config_path.is_absolute():
+        config_path = root / config_path
+
+    if not config_path.exists():
+        return APISettings(None, None, None, None, None, None)
+
+    try:
+        with config_path.open("r", encoding="utf-8") as handle:
+            raw: Dict[str, Any] = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Impossible de lire les clefs API depuis {config_path}: JSON invalide"
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(
+            f"Impossible d'ouvrir le fichier de clefs API {config_path}"
+        ) from exc
+
+    return APISettings(
+        google_books_api_key=_normalise(raw.get("google_books_api_key")),
+        kitsu_client_id=_normalise(raw.get("kitsu_client_id")),
+        kitsu_client_secret=_normalise(raw.get("kitsu_client_secret")),
+        anilist_client_id=_normalise(raw.get("anilist_client_id")),
+        anilist_client_secret=_normalise(raw.get("anilist_client_secret")),
+        comic_vine_api_key=_normalise(raw.get("comic_vine_api_key")),
+    )

--- a/api_keys.example.json
+++ b/api_keys.example.json
@@ -1,0 +1,8 @@
+{
+  "google_books_api_key": "VOTRE_CLE_GOOGLE_BOOKS",
+  "kitsu_client_id": "",
+  "kitsu_client_secret": "",
+  "anilist_client_id": "",
+  "anilist_client_secret": "",
+  "comic_vine_api_key": ""
+}

--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - executed when python-dotenv is absent
     load_dotenv = None  # type: ignore
 
+from api_config import APISettings, load_api_settings
 
 if load_dotenv is not None:  # pragma: no cover - simple delegation
     # Load a .env file located at the project root if present. ``override``
@@ -52,6 +53,7 @@ class Settings:
     environment: str
     host: str
     port: int
+    api_settings: APISettings
 
 
 def _resolve_directory(root: Path, candidate: Optional[str], default: str) -> Path:
@@ -150,6 +152,7 @@ def get_settings(root_path: Path | str) -> Settings:
         environment=environment,
         host=host,
         port=port,
+        api_settings=load_api_settings(root),
     )
 
 
@@ -173,6 +176,7 @@ def configure_app(app):
     app.config["BOOKSTORAGE_SECRET_FROM_ENV"] = settings.secret_from_env
     app.config.setdefault("BOOKSTORAGE_HOST", settings.host)
     app.config.setdefault("BOOKSTORAGE_PORT", settings.port)
+    app.config.setdefault("BOOKSTORAGE_API_SETTINGS", settings.api_settings)
 
     if settings.environment == "production":
         # Harden session cookies by default when the production profile is

--- a/metadata_providers.py
+++ b/metadata_providers.py
@@ -1,0 +1,174 @@
+"""Utilities to retrieve metadata about works from public APIs."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence
+from urllib import error, parse, request
+
+
+OPEN_LIBRARY_ENDPOINT = "https://openlibrary.org/search.json"
+DEFAULT_RESULT_LIMIT = 8
+
+
+READING_TYPE_KEYWORDS = {
+    "Manga": {"manga"},
+    "BD": {"bd", "bande dessinée", "bandes dessinées"},
+    "Manhwa": {"manhwa"},
+    "Light Novel": {"light novel", "light novels"},
+    "Comics": {"comic", "comics", "graphic novel", "graphic novels"},
+    "Webtoon": {"webtoon", "webtoons", "webcomic", "webcomics"},
+}
+
+
+@dataclass(frozen=True)
+class MetadataSuggestion:
+    """Structured information returned by a metadata provider."""
+
+    title: str
+    authors: List[str]
+    info_url: Optional[str]
+    cover_url: Optional[str]
+    reading_type: str
+    published_year: Optional[int]
+    summary: Optional[str]
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serialisable representation."""
+
+        return {
+            "title": self.title,
+            "authors": self.authors,
+            "info_url": self.info_url,
+            "cover_url": self.cover_url,
+            "reading_type": self.reading_type,
+            "published_year": self.published_year,
+            "summary": self.summary,
+        }
+
+
+def _normalise_summary(doc: dict) -> Optional[str]:
+    summary = doc.get("first_sentence") or doc.get("subtitle")
+    if isinstance(summary, dict):
+        summary = summary.get("value")
+    if isinstance(summary, list):
+        summary = " ".join([part for part in summary if isinstance(part, str)])
+    if isinstance(summary, str):
+        summary = summary.strip()
+    return summary or None
+
+
+def _normalise_authors(doc: dict) -> List[str]:
+    names = doc.get("author_name") or []
+    return [name for name in names if isinstance(name, str) and name.strip()]
+
+
+def _extract_subjects(doc: dict) -> List[str]:
+    subjects = doc.get("subject_facet") or doc.get("subject") or []
+    if not isinstance(subjects, Iterable):
+        return []
+    normalised = []
+    for subject in subjects:
+        if isinstance(subject, str):
+            normalised.append(subject.strip().lower())
+    return normalised
+
+
+def _guess_reading_type(
+    *,
+    available_types: Sequence[str],
+    subjects: Sequence[str],
+    title: str,
+) -> str:
+    if not available_types:
+        return "Autre"
+
+    lowered_title = title.lower()
+    for reading_type in available_types:
+        keywords = READING_TYPE_KEYWORDS.get(reading_type, set())
+        if not keywords:
+            continue
+        for keyword in keywords:
+            if keyword in lowered_title:
+                return reading_type
+            if any(keyword in subject for subject in subjects):
+                return reading_type
+
+    return available_types[0]
+
+
+def search_open_library(
+    query: str,
+    *,
+    available_types: Sequence[str],
+    limit: int = DEFAULT_RESULT_LIMIT,
+    opener=request.urlopen,
+) -> List[MetadataSuggestion]:
+    """Search the Open Library catalogue and normalise the output."""
+
+    if not query or not query.strip():
+        return []
+
+    payload = parse.urlencode({"title": query.strip(), "limit": str(limit)})
+    url = f"{OPEN_LIBRARY_ENDPOINT}?{payload}"
+
+    try:
+        with opener(url, timeout=5) as response:
+            status = getattr(response, "status", None)
+            if status is None and hasattr(response, "getcode"):
+                status = response.getcode()
+            if status != 200:
+                return []
+            raw = response.read()
+    except (error.URLError, TimeoutError, ValueError, OSError):
+        return []
+
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return []
+
+    docs = data.get("docs", [])
+    suggestions: List[MetadataSuggestion] = []
+    for doc in docs:
+        if not isinstance(doc, dict):
+            continue
+        title = doc.get("title")
+        if not isinstance(title, str) or not title.strip():
+            continue
+
+        cover_id = doc.get("cover_i")
+        cover_url = None
+        if isinstance(cover_id, int):
+            cover_url = f"https://covers.openlibrary.org/b/id/{cover_id}-L.jpg"
+
+        info_url = None
+        key = doc.get("key")
+        if isinstance(key, str) and key.strip():
+            info_url = f"https://openlibrary.org{key}"
+
+        summary = _normalise_summary(doc)
+        authors = _normalise_authors(doc)
+        subjects = _extract_subjects(doc)
+        reading_type = _guess_reading_type(
+            available_types=available_types,
+            subjects=subjects,
+            title=title,
+        )
+        published = doc.get("first_publish_year")
+        published_year = int(published) if isinstance(published, int) else None
+
+        suggestions.append(
+            MetadataSuggestion(
+                title=title.strip(),
+                authors=authors,
+                info_url=info_url,
+                cover_url=cover_url,
+                reading_type=reading_type,
+                published_year=published_year,
+                summary=summary,
+            )
+        )
+
+    return suggestions

--- a/static/css/add_work.css
+++ b/static/css/add_work.css
@@ -27,10 +27,114 @@
   grid-column: 1 / -1;
 }
 
+.form-field--wide {
+  grid-column: 1 / -1;
+}
+
+.metadata-input-group {
+  display: flex;
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.metadata-input-group input {
+  flex: 1;
+}
+
+.metadata-input-group .btn-outline {
+  border: 1px solid var(--primary);
+  background: rgba(79, 70, 229, 0.08);
+  color: var(--primary);
+  box-shadow: none;
+  white-space: nowrap;
+}
+
+.metadata-input-group .btn-outline:hover,
+.metadata-input-group .btn-outline:focus-visible {
+  background: rgba(79, 70, 229, 0.18);
+  color: var(--primary-dark);
+}
+
+.metadata-results {
+  margin-top: 2.5rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.metadata-results header h2 {
+  margin-bottom: 0.25rem;
+}
+
+.metadata-results-list {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.metadata-card {
+  background: var(--surface-elevated);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: var(--radius);
+  padding: 1.1rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.8rem;
+}
+
+.metadata-card header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.metadata-cover {
+  width: 72px;
+  height: 108px;
+  border-radius: calc(var(--radius) / 2);
+  object-fit: cover;
+  box-shadow: 0 12px 22px rgba(15, 23, 42, 0.18);
+}
+
+.metadata-info h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.metadata-info p {
+  margin: 0.25rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.metadata-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.metadata-footer .badge {
+  background: var(--primary-muted);
+  color: var(--primary-dark);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.metadata-footer .btn {
+  font-size: 0.9rem;
+  padding: 0.5rem 1.1rem;
+}
+
 .field-hint {
   font-size: 0.85rem;
   color: var(--text-muted);
   margin: 0;
+}
+
+#metadata-status.error {
+  color: #b91c1c;
 }
 
 .form-actions {

--- a/static/js/add_work_search.js
+++ b/static/js/add_work_search.js
@@ -1,0 +1,161 @@
+(function () {
+  const titleInput = document.getElementById("title");
+  const linkInput = document.getElementById("link");
+  const readingTypeSelect = document.getElementById("reading_type");
+  const coverField = document.getElementById("metadata_cover_url");
+  const infoField = document.getElementById("metadata_info_url");
+  const searchButton = document.getElementById("metadata-search");
+  const resultsSection = document.getElementById("metadata-results");
+  const resultsList = document.getElementById("metadata-results-list");
+  const statusLabel = document.getElementById("metadata-status");
+
+  if (!titleInput || !searchButton || !resultsSection || !resultsList || !statusLabel) {
+    return;
+  }
+
+  function setStatus(message, isError) {
+    statusLabel.textContent = message;
+    if (isError) {
+      statusLabel.classList.add("error");
+    } else {
+      statusLabel.classList.remove("error");
+    }
+  }
+
+  function clearResults() {
+    resultsList.innerHTML = "";
+  }
+
+  function applySuggestion(suggestion) {
+    titleInput.value = suggestion.title || titleInput.value;
+    if (suggestion.info_url) {
+      infoField.value = suggestion.info_url;
+      if (linkInput) {
+        linkInput.value = suggestion.info_url;
+      }
+    }
+    if (readingTypeSelect && suggestion.reading_type) {
+      const option = Array.from(readingTypeSelect.options).find(
+        (opt) => opt.value === suggestion.reading_type
+      );
+      if (option) {
+        readingTypeSelect.value = option.value;
+      }
+    }
+    if (suggestion.cover_url) {
+      coverField.value = suggestion.cover_url;
+    } else {
+      coverField.value = "";
+    }
+    setStatus("Suggestion appliquée. Vous pouvez ajuster les informations avant l'enregistrement.", false);
+  }
+
+  function createResultCard(suggestion) {
+    const card = document.createElement("article");
+    card.className = "metadata-card";
+    card.setAttribute("role", "listitem");
+
+    const header = document.createElement("header");
+    if (suggestion.cover_url) {
+      const image = document.createElement("img");
+      image.src = suggestion.cover_url;
+      image.alt = `Couverture proposée pour ${suggestion.title}`;
+      image.className = "metadata-cover";
+      header.appendChild(image);
+    }
+
+    const info = document.createElement("div");
+    info.className = "metadata-info";
+
+    const title = document.createElement("h3");
+    title.textContent = suggestion.title;
+    info.appendChild(title);
+
+    if (suggestion.authors && suggestion.authors.length > 0) {
+      const authors = document.createElement("p");
+      authors.textContent = `Auteur(s) : ${suggestion.authors.join(", ")}`;
+      info.appendChild(authors);
+    }
+
+    if (suggestion.published_year) {
+      const year = document.createElement("p");
+      year.textContent = `Première publication : ${suggestion.published_year}`;
+      info.appendChild(year);
+    }
+
+    if (suggestion.summary) {
+      const summary = document.createElement("p");
+      summary.textContent = suggestion.summary;
+      info.appendChild(summary);
+    }
+
+    header.appendChild(info);
+    card.appendChild(header);
+
+    const footer = document.createElement("div");
+    footer.className = "metadata-footer";
+
+    const typeBadge = document.createElement("span");
+    typeBadge.className = "badge";
+    typeBadge.textContent = suggestion.reading_type || "Type";
+    footer.appendChild(typeBadge);
+
+    const useButton = document.createElement("button");
+    useButton.type = "button";
+    useButton.className = "btn btn-primary";
+    useButton.textContent = "Utiliser";
+    useButton.addEventListener("click", function () {
+      applySuggestion(suggestion);
+    });
+
+    footer.appendChild(useButton);
+    card.appendChild(footer);
+
+    return card;
+  }
+
+  function renderResults(results) {
+    clearResults();
+    if (!results || results.length === 0) {
+      resultsSection.hidden = false;
+      setStatus("Aucune proposition trouvée. Essayez un autre titre ou ajoutez l'œuvre manuellement.", true);
+      return;
+    }
+
+    results.forEach((suggestion) => {
+      resultsList.appendChild(createResultCard(suggestion));
+    });
+    resultsSection.hidden = false;
+    setStatus("Sélectionnez l'une des suggestions pour préremplir le formulaire.", false);
+  }
+
+  async function triggerSearch() {
+    const query = titleInput.value.trim();
+    if (!query) {
+      setStatus("Indiquez d'abord un titre ou un identifiant.", true);
+      resultsSection.hidden = true;
+      clearResults();
+      return;
+    }
+
+    searchButton.disabled = true;
+    setStatus("Recherche en cours…", false);
+    try {
+      const response = await fetch(`/api/metadata/search?q=${encodeURIComponent(query)}`);
+      if (!response.ok) {
+        throw new Error(`Statut ${response.status}`);
+      }
+      const payload = await response.json();
+      renderResults(payload.results || []);
+    } catch (error) {
+      console.error("metadata lookup failed", error);
+      setStatus("La recherche a échoué. Vérifiez votre connexion et réessayez.", true);
+      resultsSection.hidden = false;
+      clearResults();
+    } finally {
+      searchButton.disabled = false;
+    }
+  }
+
+  searchButton.addEventListener("click", triggerSearch);
+})();

--- a/templates/add_work.html
+++ b/templates/add_work.html
@@ -12,9 +12,13 @@
 
   <form method="POST" enctype="multipart/form-data" class="form-layout card">
     <div class="form-grid">
-      <div class="form-field">
+      <div class="form-field form-field--wide">
         <label for="title">Titre</label>
-        <input id="title" type="text" name="title" maxlength="60" required>
+        <div class="metadata-input-group">
+          <input id="title" type="text" name="title" maxlength="60" required>
+          <button type="button" id="metadata-search" class="btn btn-outline">Rechercher des infos</button>
+        </div>
+        <p class="field-hint">Renseignez un titre ou un ISBN puis lancez la recherche pour préremplir les autres champs.</p>
       </div>
 
       <div class="form-field">
@@ -58,6 +62,18 @@
       <a class="btn btn-secondary" href="{{ url_for('dashboard') }}">Annuler</a>
       <button type="submit" class="btn btn-primary">Ajouter à ma bibliothèque</button>
     </div>
+    <input type="hidden" id="metadata_cover_url" name="metadata_cover_url">
+    <input type="hidden" id="metadata_info_url" name="metadata_info_url">
   </form>
+
+  <section id="metadata-results" class="metadata-results" hidden>
+    <header>
+      <h2>Suggestions d'œuvres</h2>
+      <p id="metadata-status" class="field-hint">Sélectionnez une proposition pour remplir le formulaire automatiquement.</p>
+    </header>
+    <div id="metadata-results-list" class="metadata-results-list" role="list"></div>
+  </section>
 </section>
+
+<script src="{{ url_for('static', filename='js/add_work_search.js') }}" defer></script>
 {% endblock %}

--- a/tests/test_api_config.py
+++ b/tests/test_api_config.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from api_config import APISettings, load_api_settings
+
+
+def test_missing_file_returns_empty_settings(tmp_path, monkeypatch):
+    monkeypatch.delenv("BOOKSTORAGE_API_CONFIG", raising=False)
+
+    settings = load_api_settings(tmp_path)
+
+    assert settings == APISettings(None, None, None, None, None, None)
+
+
+def test_load_api_settings_reads_values(tmp_path, monkeypatch):
+    monkeypatch.delenv("BOOKSTORAGE_API_CONFIG", raising=False)
+    config_path = tmp_path / "api_keys.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "google_books_api_key": "  token  ",
+                "kitsu_client_id": "client",
+                "kitsu_client_secret": "secret",
+                "anilist_client_id": "",
+                "anilist_client_secret": None,
+                "comic_vine_api_key": "123",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    settings = load_api_settings(tmp_path)
+
+    assert settings.google_books_api_key == "token"
+    assert settings.kitsu_client_id == "client"
+    assert settings.kitsu_client_secret == "secret"
+    assert settings.anilist_client_id is None
+    assert settings.anilist_client_secret is None
+    assert settings.comic_vine_api_key == "123"
+
+
+def test_environment_override_accepts_absolute_path(tmp_path, monkeypatch):
+    config_path = tmp_path / "custom.json"
+    config_path.write_text(json.dumps({"google_books_api_key": "abc"}), encoding="utf-8")
+    monkeypatch.setenv("BOOKSTORAGE_API_CONFIG", str(config_path))
+
+    settings = load_api_settings(Path("/does/not/matter"))
+
+    assert settings.google_books_api_key == "abc"
+    assert settings.kitsu_client_id is None

--- a/tests/test_metadata_providers.py
+++ b/tests/test_metadata_providers.py
@@ -1,0 +1,98 @@
+import io
+import json
+
+import pytest
+
+from metadata_providers import search_open_library
+
+
+class DummyResponse(io.BytesIO):
+    def __init__(self, payload: dict, status: int = 200):
+        data = json.dumps(payload).encode("utf-8")
+        super().__init__(data)
+        self.status = status
+        self.headers = {"Content-Type": "application/json"}
+
+    def __enter__(self):
+        self.seek(0)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
+    def read(self, *args, **kwargs):
+        return super().read(*args, **kwargs)
+
+    def getcode(self):
+        return self.status
+
+
+@pytest.mark.parametrize(
+    "subjects,expected",
+    [
+        (["Manga", "Adventure"], "Manga"),
+        (["Graphic Novels", "Comic books"], "Comics"),
+        ([], "Roman"),
+    ],
+)
+def test_search_open_library_normalises_results(subjects, expected):
+    payload = {
+        "docs": [
+            {
+                "title": "Naruto",
+                "author_name": ["Masashi Kishimoto"],
+                "cover_i": 12345,
+                "key": "/works/OL123W",
+                "first_publish_year": 1999,
+                "subject_facet": subjects,
+                "first_sentence": {"value": "Un jeune ninja rêve de reconnaissance."},
+            }
+        ]
+    }
+
+    def opener(url, timeout=5):
+        assert "title=Naruto" in url
+        return DummyResponse(payload)
+
+    suggestions = search_open_library(
+        "Naruto",
+        available_types=["Roman", "Manga", "Comics"],
+        limit=5,
+        opener=opener,
+    )
+
+    assert len(suggestions) == 1
+    suggestion = suggestions[0]
+    assert suggestion.title == "Naruto"
+    assert suggestion.authors == ["Masashi Kishimoto"]
+    assert suggestion.cover_url == "https://covers.openlibrary.org/b/id/12345-L.jpg"
+    assert suggestion.info_url == "https://openlibrary.org/works/OL123W"
+    assert suggestion.published_year == 1999
+    assert suggestion.summary == "Un jeune ninja rêve de reconnaissance."
+    assert suggestion.reading_type == expected
+
+
+def test_search_open_library_handles_errors_gracefully():
+    def failing_opener(url, timeout=5):
+        raise OSError("network down")
+
+    results = search_open_library(
+        "Titre",
+        available_types=["Roman"],
+        opener=failing_opener,
+    )
+
+    assert results == []
+
+    bad_payload = DummyResponse({"docs": ["not-a-dict"]})
+
+    def invalid_opener(url, timeout=5):
+        return bad_payload
+
+    results = search_open_library(
+        "Titre",
+        available_types=["Roman"],
+        opener=invalid_opener,
+    )
+
+    assert results == []

--- a/tests/test_metadata_route.py
+++ b/tests/test_metadata_route.py
@@ -1,0 +1,116 @@
+import io
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+import app
+from metadata_providers import MetadataSuggestion
+
+
+def login_reader(client):
+    client.post(
+        "/login",
+        data={"username": "reader", "password": "ReaderPass!1"},
+        follow_redirects=True,
+    )
+
+
+def test_metadata_endpoint_returns_json(monkeypatch, client):
+    login_reader(client)
+
+    fake_results = [
+        MetadataSuggestion(
+            title="Chainsaw Man",
+            authors=["Tatsuki Fujimoto"],
+            info_url="https://openlibrary.org/works/OL12345W",
+            cover_url="https://covers.openlibrary.org/b/id/12345-L.jpg",
+            reading_type="Manga",
+            published_year=2019,
+            summary="Denji lutte contre les démons.",
+        )
+    ]
+
+    monkeypatch.setattr(app, "search_open_library", lambda query, available_types: fake_results)
+
+    response = client.get("/api/metadata/search", query_string={"q": "Chainsaw"})
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["results"][0]["title"] == "Chainsaw Man"
+    assert payload["results"][0]["reading_type"] == "Manga"
+    assert payload["results"][0]["cover_url"].endswith("12345-L.jpg")
+
+
+def test_add_work_uses_metadata_cover(monkeypatch, client, get_user_record, database_path):
+    login_reader(client)
+
+    covers_dir = Path(client.application.config["UPLOAD_FOLDER"])
+    covers_dir.mkdir(parents=True, exist_ok=True)
+
+    fake_bytes = b"\xffDUMMY"
+
+    class FakeResponse(io.BytesIO):
+        def __init__(self):
+            super().__init__(fake_bytes)
+            self.status = 200
+            self.headers = {"Content-Type": "image/jpeg"}
+
+        def __enter__(self):
+            self.seek(0)
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+        def read(self, *args, **kwargs):
+            return super().read(*args, **kwargs)
+
+        def getcode(self):
+            return self.status
+
+    def opener(url, timeout=5):
+        assert "covers.openlibrary.org" in url
+        return FakeResponse()
+
+    monkeypatch.setattr(app.uuid, "uuid4", lambda: SimpleNamespace(hex="metadatauuid"))
+
+    image_path = app._download_remote_cover(
+        "https://covers.openlibrary.org/b/id/999-L.jpg",
+        opener=opener,
+    )
+
+    assert image_path is not None
+    stored_file = covers_dir / Path(image_path).name
+    assert stored_file.exists()
+    assert stored_file.read_bytes() == fake_bytes
+
+    monkeypatch.setattr(app, "_download_remote_cover", lambda url: image_path)
+
+    response = client.post(
+        "/add_work",
+        data={
+            "title": "Chainsaw Man",
+            "status": "En cours",
+            "chapter": "12",
+            "reading_type": "Manga",
+            "metadata_cover_url": "https://covers.openlibrary.org/b/id/999-L.jpg",
+            "metadata_info_url": "https://openlibrary.org/works/OL12345W",
+            "link": "",
+        },
+        follow_redirects=True,
+    )
+    assert "Oeuvre ajoutée" in response.get_data(as_text=True)
+
+    reader = get_user_record("reader")
+    conn = sqlite3.connect(database_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        work = conn.execute(
+            "SELECT * FROM works WHERE user_id = ? AND title = ?",
+            (reader["id"], "Chainsaw Man"),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert work is not None
+    assert work["link"] == "https://openlibrary.org/works/OL12345W"
+    assert work["image_path"] == image_path


### PR DESCRIPTION
## Summary
- integrate an Open Library metadata provider and expose a backend search endpoint that can download suggested covers
- enhance the add-work form with a search UI, styling, and JavaScript to prefill fields from metadata suggestions, updating the README in English and French
- cover the new provider, endpoint, and remote cover workflow with dedicated unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d505c459cc832dac63107d711413da