### PR TITLE
Add ability to edit existing works

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,6 +31,15 @@ READING_TYPES = [
 ]
 
 
+READING_STATUSES = [
+    "En cours",
+    "Terminé",
+    "En pause",
+    "Abandonné",
+    "À lire",
+]
+
+
 def _resolve_media_path(stored_path, config_key):
     if not stored_path:
         return None
@@ -618,7 +627,9 @@ def add_work():
             flash("Le titre ne doit pas dépasser 30 caractères.")
             return redirect(url_for("add_work"))
         link = request.form["link"]
-        status = request.form["status"]
+        status = request.form.get("status", READING_STATUSES[0])
+        if status not in READING_STATUSES:
+            status = READING_STATUSES[0]
         chapter = request.form.get("chapter", 0)
         chapter = int(chapter) if chapter else 0
         reading_type = request.form.get("reading_type", "").strip()
@@ -656,7 +667,123 @@ def add_work():
 
         flash("Oeuvre ajoutée avec succès !")
         return redirect(url_for("dashboard"))
-    return render_template("add_work.html", reading_types=READING_TYPES)
+    return render_template(
+        "add_work.html",
+        reading_types=READING_TYPES,
+        statuses=READING_STATUSES,
+    )
+
+
+@app.route("/edit/<int:work_id>", methods=["GET", "POST"])
+@login_required
+def edit_work(work_id):
+    user_id = session["user_id"]
+    conn = get_db_connection()
+    work = conn.execute(
+        "SELECT * FROM works WHERE id = ? AND user_id = ?",
+        (work_id, user_id),
+    ).fetchone()
+
+    if not work:
+        conn.close()
+        flash("Œuvre introuvable.")
+        return redirect(url_for("dashboard"))
+
+    work_data = dict(work)
+
+    if request.method == "POST":
+        title = request.form.get("title", "").strip()
+        if not title:
+            flash("Le titre est requis.")
+            conn.close()
+            return redirect(url_for("edit_work", work_id=work_id))
+        if len(title) > 30:
+            flash("Le titre ne doit pas dépasser 30 caractères.")
+            conn.close()
+            return redirect(url_for("edit_work", work_id=work_id))
+
+        link = request.form.get("link", "").strip()
+        status = request.form.get("status", READING_STATUSES[0])
+        if status not in READING_STATUSES:
+            status = READING_STATUSES[0]
+        chapter = request.form.get("chapter", 0)
+        chapter = int(chapter) if chapter else 0
+        if chapter < 0:
+            chapter = 0
+
+        reading_type = request.form.get("reading_type", "").strip()
+        if not reading_type:
+            reading_type = READING_TYPES[0]
+        elif reading_type not in READING_TYPES:
+            flash("Type de lecture invalide.")
+            conn.close()
+            return redirect(url_for("edit_work", work_id=work_id))
+
+        previous_image = work_data.get("image_path")
+        new_image_path = previous_image
+        new_image_uploaded = False
+
+        if "image" in request.files:
+            file = request.files["image"]
+            if file and file.filename:
+                if not allowed_file(file.filename):
+                    flash(
+                        "Format d'image non supporté. Formats acceptés : png, jpg, jpeg, gif."
+                    )
+                    conn.close()
+                    return redirect(url_for("edit_work", work_id=work_id))
+                safe_name = secure_filename(file.filename)
+                if not safe_name:
+                    safe_name = "work"
+                filename = f"{uuid.uuid4().hex}_{safe_name}"
+                storage_dir = app.config["UPLOAD_FOLDER"]
+                if not os.path.isabs(storage_dir):
+                    storage_dir = os.path.join(app.root_path, storage_dir)
+                os.makedirs(storage_dir, exist_ok=True)
+                filepath = os.path.join(storage_dir, filename)
+                file.save(filepath)
+                new_image_path = _build_media_relative_path(
+                    filename, "UPLOAD_URL_PATH"
+                )
+                new_image_uploaded = True
+
+        conn.execute(
+            """
+            UPDATE works
+               SET title = ?,
+                   chapter = ?,
+                   link = ?,
+                   status = ?,
+                   image_path = ?,
+                   reading_type = ?
+             WHERE id = ? AND user_id = ?
+            """,
+            (title, chapter, link, status, new_image_path, reading_type, work_id, user_id),
+        )
+        conn.commit()
+
+        if new_image_uploaded and previous_image and previous_image != new_image_path:
+            remaining = conn.execute(
+                "SELECT COUNT(*) FROM works WHERE image_path = ? AND id != ?",
+                (previous_image, work_id),
+            ).fetchone()[0]
+            if remaining == 0:
+                _delete_media_file(previous_image, "UPLOAD_FOLDER")
+
+        conn.close()
+        flash("Œuvre mise à jour.")
+        return redirect(url_for("dashboard"))
+
+    conn.close()
+    work_data["link"] = work_data.get("link") or ""
+    work_data["status"] = work_data.get("status") or READING_STATUSES[0]
+    work_data["reading_type"] = work_data.get("reading_type") or READING_TYPES[0]
+    return render_template(
+        "edit_work.html",
+        work=work_data,
+        reading_types=READING_TYPES,
+        statuses=READING_STATUSES,
+    )
 
 # Endpoints API pour incrémenter/décrémenter les chapitres (via AJAX)
 @app.route("/api/increment/<int:work_id>", methods=["POST"])

--- a/static/css/add_work.css
+++ b/static/css/add_work.css
@@ -33,6 +33,23 @@
   margin: 0;
 }
 
+.current-cover {
+  margin-top: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.current-cover img {
+  width: 90px;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 12px;
+  box-shadow: 0 12px 22px rgba(15, 23, 42, 0.15);
+}
+
 .form-actions {
   justify-content: flex-end;
   margin-top: 1.75rem;

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -155,6 +155,17 @@
   background: rgba(15, 23, 42, 0.12);
 }
 
+.btn-icon.primary {
+  background: rgba(14, 165, 233, 0.18);
+  color: #0369a1;
+  box-shadow: none;
+}
+
+.btn-icon.primary:hover,
+.btn-icon.primary:focus-visible {
+  background: rgba(14, 165, 233, 0.26);
+}
+
 .btn-icon.danger {
   background: rgba(239, 68, 68, 0.16);
   color: #b91c1c;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -100,6 +100,7 @@
               <button type="button" class="btn btn-icon neutral decrement-btn" data-work-id="{{ work.id }}" aria-label="Retirer un chapitre">
                 −1
               </button>
+              <a class="btn btn-icon primary" href="{{ url_for('edit_work', work_id=work.id) }}">Modifier</a>
               <a class="btn btn-icon danger" href="{{ url_for('delete', work_id=work.id) }}" onclick="return confirm('Supprimer cette œuvre de la bibliothèque ?');">Supprimer</a>
             </div>
           </td>

--- a/templates/edit_work.html
+++ b/templates/edit_work.html
@@ -1,32 +1,32 @@
 {% extends "base.html" %}
-{% block title %}Ajouter une œuvre{% endblock %}
+{% block title %}Modifier {{ work.title }}{% endblock %}
 {% block custom_css %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/add_work.css') }}">
 {% endblock %}
 {% block content %}
 <section class="page-section">
   <header class="section-header">
-    <h1>Ajouter une œuvre</h1>
-    <p>Complétez les informations ci-dessous pour enrichir votre bibliothèque personnelle. Les champs peuvent être modifiés à tout moment depuis le tableau de bord.</p>
+    <h1>Modifier une œuvre</h1>
+    <p>Actualisez les informations de cette œuvre pour garder votre bibliothèque à jour.</p>
   </header>
 
   <form method="POST" enctype="multipart/form-data" class="form-layout card">
     <div class="form-grid">
       <div class="form-field">
         <label for="title">Titre</label>
-        <input id="title" type="text" name="title" maxlength="60" required>
+        <input id="title" type="text" name="title" maxlength="60" value="{{ work.title }}" required>
       </div>
 
       <div class="form-field">
         <label for="chapter">Chapitre actuel</label>
-        <input id="chapter" type="number" name="chapter" min="0" value="0">
+        <input id="chapter" type="number" name="chapter" min="0" value="{{ work.chapter }}">
       </div>
 
       <div class="form-field">
         <label for="status">Statut de lecture</label>
         <select id="status" name="status">
           {% for status in statuses %}
-          <option value="{{ status }}" {% if loop.first %}selected{% endif %}>{{ status }}</option>
+          <option value="{{ status }}" {% if work.status == status %}selected{% endif %}>{{ status }}</option>
           {% endfor %}
         </select>
       </div>
@@ -35,26 +35,32 @@
         <label for="reading_type">Type de lecture</label>
         <select id="reading_type" name="reading_type" required>
           {% for reading_type in reading_types %}
-          <option value="{{ reading_type }}">{{ reading_type }}</option>
+          <option value="{{ reading_type }}" {% if work.reading_type == reading_type %}selected{% endif %}>{{ reading_type }}</option>
           {% endfor %}
         </select>
       </div>
 
       <div class="form-field">
         <label for="link">Lien vers la ressource</label>
-        <input id="link" type="url" name="link" placeholder="https://...">
+        <input id="link" type="url" name="link" placeholder="https://..." value="{{ work.link }}">
       </div>
 
       <div class="form-field">
         <label for="image">Image de couverture</label>
         <input id="image" type="file" name="image" accept="image/*">
-        <p class="field-hint">Formats conseillés : JPG ou PNG (taille max. 2&nbsp;Mo).</p>
+        <p class="field-hint">Laissez vide pour conserver l'image actuelle.</p>
+        {% if work.image_path %}
+        <div class="current-cover">
+          <span>Image actuelle :</span>
+          <img src="{{ url_for('static', filename=work.image_path) }}" alt="Image actuelle de {{ work.title }}">
+        </div>
+        {% endif %}
       </div>
     </div>
 
     <div class="form-actions">
       <a class="btn btn-secondary" href="{{ url_for('dashboard') }}">Annuler</a>
-      <button type="submit" class="btn btn-primary">Ajouter à ma bibliothèque</button>
+      <button type="submit" class="btn btn-primary">Enregistrer les modifications</button>
     </div>
   </form>
 </section>


### PR DESCRIPTION
## Summary
- add reusable status constants and expose them to work forms
- implement an edit route and template to update existing works, including cover management
- update the dashboard UI with an edit action and styling tweaks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d52447d7e0832d9ac62028be68f206