### PR TITLE
Fix work cover image URLs

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,6 +36,36 @@ READING_STATUSES = [
 ]
 
 
+@app.context_processor
+def _media_helpers():
+    def work_image_url(stored_path):
+        if not stored_path:
+            return None
+
+        normalized = str(stored_path).strip()
+        if not normalized:
+            return None
+
+        if normalized.startswith(("http://", "https://", "//", "data:")):
+            return normalized
+
+        normalized = normalized.replace("\\", "/")
+
+        if normalized.startswith("/static/"):
+            normalized = normalized[len("/static/") :]
+            return url_for("static", filename=normalized)
+
+        if normalized.startswith("/"):
+            return normalized
+
+        if normalized.startswith("static/"):
+            normalized = normalized[len("static/") :]
+
+        return url_for("static", filename=normalized.lstrip("/"))
+
+    return {"work_image_url": work_image_url}
+
+
 def _resolve_media_path(stored_path, config_key):
     if not stored_path:
         return None

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -67,8 +67,9 @@
         {% for work in works %}
         <tr>
           <td class="cover-cell">
-            {% if work.image_path %}
-              <img src="{{ url_for('static', filename=work.image_path) }}" alt="Image de {{ work.title }}">
+            {% set image_url = work_image_url(work.image_path) %}
+            {% if image_url %}
+              <img src="{{ image_url }}" alt="Image de {{ work.title }}">
             {% else %}
               <span class="badge info">Pas d'image</span>
             {% endif %}

--- a/templates/edit_work.html
+++ b/templates/edit_work.html
@@ -49,10 +49,11 @@
         <label for="image">Image de couverture</label>
         <input id="image" type="file" name="image" accept="image/*">
         <p class="field-hint">Laissez vide pour conserver l'image actuelle.</p>
-        {% if work.image_path %}
+        {% set image_url = work_image_url(work.image_path) %}
+        {% if image_url %}
         <div class="current-cover">
           <span>Image actuelle :</span>
-          <img src="{{ url_for('static', filename=work.image_path) }}" alt="Image actuelle de {{ work.title }}">
+          <img src="{{ image_url }}" alt="Image actuelle de {{ work.title }}">
         </div>
         {% endif %}
       </div>


### PR DESCRIPTION
## Summary
- add a template helper that normalises stored work cover paths and resolves the correct URL
- update the dashboard and edit pages to use the helper so missing or malformed paths fall back gracefully

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5368babd8832dac1a3949f3d3d5af