### PR TITLE
Serve uploaded media from configurable paths

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -67,8 +67,9 @@
         {% for work in works %}
         <tr>
           <td class="cover-cell">
-            {% if work.image_path %}
-              <img src="{{ url_for('static', filename=work.image_path) }}" alt="Image de {{ work.title }}">
+            {% set image_url = work_image_url(work.image_path) %}
+            {% if image_url %}
+              <img src="{{ image_url }}" alt="Image de {{ work.title }}">
             {% else %}
               <span class="badge info">Pas d'image</span>
             {% endif %}

--- a/templates/edit_work.html
+++ b/templates/edit_work.html
@@ -49,10 +49,11 @@
         <label for="image">Image de couverture</label>
         <input id="image" type="file" name="image" accept="image/*">
         <p class="field-hint">Laissez vide pour conserver l'image actuelle.</p>
-        {% if work.image_path %}
+        {% set image_url = work_image_url(work.image_path) %}
+        {% if image_url %}
         <div class="current-cover">
           <span>Image actuelle :</span>
-          <img src="{{ url_for('static', filename=work.image_path) }}" alt="Image actuelle de {{ work.title }}">
+          <img src="{{ image_url }}" alt="Image actuelle de {{ work.title }}">
         </div>
         {% endif %}
       </div>

--- a/tests/test_media_helpers.py
+++ b/tests/test_media_helpers.py
@@ -1,0 +1,40 @@
+import pytest
+
+from app import _media_helpers, app as flask_app
+
+
+@pytest.mark.parametrize(
+    "stored_path, expected",
+    [
+        ("images/example.png", "/images/example.png"),
+        ("avatars/profile.jpg", "/avatars/profile.jpg"),
+    ],
+)
+def test_work_image_url_uses_media_routes(stored_path, expected):
+    helpers = _media_helpers()
+    work_image_url = helpers["work_image_url"]
+
+    with flask_app.test_request_context():
+        assert work_image_url(stored_path) == expected
+
+
+def test_media_routes_follow_absolute_directories(tmp_path, monkeypatch):
+    uploads_dir = tmp_path / "uploads"
+    avatars_dir = tmp_path / "avatars"
+    uploads_dir.mkdir()
+    avatars_dir.mkdir()
+
+    monkeypatch.setitem(flask_app.config, "UPLOAD_FOLDER", str(uploads_dir))
+    monkeypatch.setitem(flask_app.config, "PROFILE_UPLOAD_FOLDER", str(avatars_dir))
+
+    # Re-register routes with the updated configuration for this test.
+    from app import _register_media_routes
+
+    _register_media_routes()
+
+    helpers = _media_helpers()
+    work_image_url = helpers["work_image_url"]
+
+    with flask_app.test_request_context():
+        assert work_image_url("images/sample.png") == "/images/sample.png"
+        assert work_image_url("avatars/pic.png") == "/avatars/pic.png"


### PR DESCRIPTION
## Summary
- add Flask routes that expose uploaded cover and avatar files from their configured storage directories
- update the template helper to resolve stored paths to the new media routes before falling back to the static handler
- cover the helper behaviour with tests for both default and absolute directory configurations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5368babd8832dac1a3949f3d3d5af